### PR TITLE
Use our Java 11 base image for ActiveMQ

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre
+FROM 345280441424.dkr.ecr.ap-south-1.amazonaws.com/ark_base_java11:latest
 
 # Environment variables: version and tarball stuff
 ENV ACTIVEMQ_VERSION 5.16.2

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -7,8 +7,10 @@ services:
       context: ..
     init: true
     ports:
-      - 5556:5556
+      - 5556:5557
       - 8161:8161
       - 61616:61616
+    environment:
+      ACTIVEMQ_SUNJMX_START: -javaagent:/app/jmx_prometheus_javaagent.jar=5557:/app/jmx-prometheus-config.yaml
     volumes:
       - ./conf:/app/conf:ro


### PR DESCRIPTION
I also added an example in the `test/docker-compose.yml` of how to change the port for the Prometheus exporter.