### PR TITLE
Add startup file to remove lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.zip
 *.tgz
 *.tar.gz
+artifacts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM 345280441424.dkr.ecr.ap-south-1.amazonaws.com/base_centos:7-20210630
 
 LABEL   ORG="Armedia LLC" \
         APP="ActiveMQ" \
-        VERSION="1.1" \
+        VERSION="1.2" \
         IMAGE_SOURCE="https://github.com/ArkCase/ark_activemq" \
         MAINTAINER="Armedia LLC"
 
@@ -33,6 +33,7 @@ ENV ACTIVEMQ="apache-activemq-$ACTIVEMQ_VERSION" \
 WORKDIR /app
 COPY activemqrc /app/home/.activemqrc
 COPY jmx-prometheus-config.yaml \
+    startup.sh \
     "artifacts/${ACTIVEMQ_TARBALL}" \
     "artifacts/${JMX_PROMETHEUS_AGENT_JAR}" \
     ./
@@ -54,4 +55,4 @@ RUN     yum -y update \
         && chown -R activemq:activemq /app/home "$ACTIVEMQ_CONF" "$ACTIVEMQ_DATA" "$ACTIVEMQ_TMP"
 
 USER activemq
-CMD ["/app/activemq/bin/activemq", "console"]
+ENTRYPOINT ["/app/startup.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ENV ACTIVEMQ_VERSION="5.16.2" \
 
 # Environment variables: tarball stuff
 ENV ACTIVEMQ="apache-activemq-$ACTIVEMQ_VERSION" \
-    JMX_PROMETHEUS_AGENT="jmx_prometheus_javaagent-${JMX_PROMETHEUS_AGENT_VERSION}.jar" \
+    ACTIVEMQ_TARBALL="apache-activemq-$ACTIVEMQ_VERSION-bin.tar.gz" \
+    JMX_PROMETHEUS_AGENT_JAR="jmx_prometheus_javaagent-${JMX_PROMETHEUS_AGENT_VERSION}.jar" \
 # Environment variables: ActiveMQ directories
     ACTIVEMQ_HOME="/app/activemq" \
     ACTIVEMQ_BASE="/app/activemq" \
@@ -32,17 +33,17 @@ ENV ACTIVEMQ="apache-activemq-$ACTIVEMQ_VERSION" \
 WORKDIR /app
 COPY activemqrc /app/home/.activemqrc
 COPY jmx-prometheus-config.yaml \
-    "artifacts/${ACTIVEMQ}-bin.tar.gz" \
-    "artifacts/${JMX_PROMETHEUS_AGENT}" \
+    "artifacts/${ACTIVEMQ_TARBALL}" \
+    "artifacts/${JMX_PROMETHEUS_AGENT_JAR}" \
     ./
 
 RUN     yum -y update \
         && yum -y install java-11-openjdk \
         && yum clean all \
-        && tar xf "${ACTIVEMQ}-bin.tar.gz" \
-        && rm "${ACTIVEMQ}-bin.tar.gz" \
+        && tar xf "${ACTIVEMQ_TARBALL}" \
+        && rm "${ACTIVEMQ_TARBALL}" \
         && ln -s "/app/$ACTIVEMQ" /app/activemq \
-        && mv "$JMX_PROMETHEUS_AGENT" jmx_prometheus_javaagent.jar \
+        && mv "$JMX_PROMETHEUS_AGENT_JAR" jmx_prometheus_javaagent.jar \
         && cd activemq \
         && rm bin/activemq-diag bin/env bin/wrapper.jar \
             activemq-all-5.16.2.jar conf/*.ts conf/*.ks \

--- a/get-artifacts.sh
+++ b/get-artifacts.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+here=$(realpath "$0")
+here=$(dirname "$here")
+cd "$here"
+
+activemq_version="5.16.2"
+activemq="apache-activemq-$activemq_version"
+activemq_sha512="27bb26786640f74dcf404db884bedffc0af4bfb2a0248c398044ac9a13e19ff097c590b79eb1404e0b04d17a8f85a8f7de87186a96744e19162d70b3c7a9bdde"
+
+jmx_prometheus_agent_version="0.15.0"
+jmx_prometheus_agent="jmx_prometheus_javaagent-${jmx_prometheus_agent_version}"
+
+rm -rf artifacts
+mkdir artifacts
+
+echo "Downloading $activemq"
+aws s3 cp "s3://arkcase-container-artifacts/ark_activemq/${activemq}-bin.tar.gz" artifacts/
+checksum=$(sha512sum "artifacts/${activemq}-bin.tar.gz" | awk '{ print $1 }')
+if [ $checksum != $activemq_sha512 ]; then
+    echo "Unexpected SHA512 checksum; possible man-in-the-middle-attack"
+    rm "${activemq}-bin.tar.gz"
+    exit 1
+fi
+
+echo "Downloading $jmx_prometheus_agent"
+aws s3 cp "s3://arkcase-container-artifacts/ark_activemq/${jmx_prometheus_agent}.jar" artifacts/

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -eu -o pipefail
+
+# Remove any pending lock file
+rm -rf /app/data/kahadb/lock
+
+exec /app/activemq/bin/activemq console


### PR DESCRIPTION
This is to try to prevent ActiveMQ going into slave mode if it wrongly detects that the KahaDB is locked (which I suspect might happen if ActiveMQ terminates uncleanly).
